### PR TITLE
Add a Kendo Input-based StepRequester form

### DIFF
--- a/privacydesk/src/pages/NewRequest/StepRequester.tsx
+++ b/privacydesk/src/pages/NewRequest/StepRequester.tsx
@@ -1,0 +1,42 @@
+import { Input } from '@progress/kendo-react-inputs';
+
+export interface Requester {
+	name: string;
+	email: string;
+	country?: string;
+}
+
+export interface StepRequesterProps {
+	value: Requester;
+	onChange: (next: Requester) => void;
+}
+
+export default function StepRequester({ value, onChange }: StepRequesterProps) {
+	return (
+		<div>
+			<div>
+				<Input
+					value={value.name}
+					onChange={(e) => onChange({ ...value, name: (e.value as string) ?? '' })}
+					placeholder="Name"
+				/>
+			</div>
+			<div>
+				<Input
+					value={value.email}
+					onChange={(e) => onChange({ ...value, email: (e.value as string) ?? '' })}
+					placeholder="Email"
+					type="email"
+				/>
+			</div>
+			<div>
+				<Input
+					value={value.country ?? ''}
+					onChange={(e) => onChange({ ...value, country: (e.value as string) ?? '' })}
+					placeholder="Country (optional)"
+				/>
+			</div>
+		</div>
+	);
+}
+

--- a/privacydesk/src/pages/NewRequest/Wizard.tsx
+++ b/privacydesk/src/pages/NewRequest/Wizard.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { Stepper } from '@progress/kendo-react-layout';
 import { Button } from '@progress/kendo-react-buttons';
+import StepRequester, { type Requester } from './StepRequester';
 
 type StepIndex = 0 | 1 | 2;
 
@@ -10,14 +11,7 @@ const steps: Array<{ label: string }> = [
 	{ label: 'Confirm' }
 ];
 
-function StepRequester() {
-	return (
-		<div>
-			<h3>Requester</h3>
-			<p>Collect requester information here.</p>
-		</div>
-	);
-}
+// Step components for Details and Confirm remain placeholders
 
 function StepDetails() {
 	return (
@@ -39,31 +33,45 @@ function StepConfirm() {
 
 export default function Wizard() {
 	const [active, setActive] = useState<StepIndex>(0);
+	const [requester, setRequester] = useState<Requester>({ name: '', email: '', country: '' });
 
 	const onStepChange = (e: any) => {
 		const next = Math.max(0, Math.min(steps.length - 1, Number(e.value) || 0)) as StepIndex;
 		setActive(next);
 	};
 
-	const handleBack = () => setActive((prev) => Math.max(0, (prev - 1) as StepIndex) as StepIndex);
-	const handleNext = () => setActive((prev) => Math.min(steps.length - 1, (prev + 1) as StepIndex) as StepIndex);
+		const handleBack = () => setActive((prev) => Math.max(0, (prev - 1) as StepIndex) as StepIndex);
+		const handleNext = () => setActive((prev) => Math.min(steps.length - 1, (prev + 1) as StepIndex) as StepIndex);
+
+		const canProceedFromRequester = useMemo(() => {
+			const hasName = requester.name.trim().length > 0;
+			const email = requester.email.trim();
+			const emailLooksValid = /.+@.+\..+/.test(email);
+			return hasName && emailLooksValid;
+		}, [requester]);
 
 	return (
 		<div>
 			<Stepper items={steps} value={active} onChange={onStepChange} />
 
-			<div>
-				{active === 0 && <StepRequester />}
+					<div>
+						{active === 0 && (
+							<StepRequester value={requester} onChange={setRequester} />
+						)}
 				{active === 1 && <StepDetails />}
 				{active === 2 && <StepConfirm />}
 			</div>
 
-			<div>
-				<Button onClick={handleBack} disabled={active === 0}>Back</Button>
-				<Button onClick={handleNext} disabled={active === steps.length - 1} themeColor="primary">
-					Next
-				</Button>
-			</div>
+					<div>
+						<Button onClick={handleBack} disabled={active === 0}>Back</Button>
+						<Button
+							onClick={handleNext}
+							disabled={(active === 0 && !canProceedFromRequester) || active === steps.length - 1}
+							themeColor="primary"
+						>
+							Next
+						</Button>
+					</div>
 		</div>
 	);
 }


### PR DESCRIPTION
### Add a Kendo Input-based StepRequester form and wire it into the wizard so Next is disabled until name and a valid-looking email are provided.

Kendo Inputs for name, email, optional country,
Controlled state in Wizard,
Disable Next until valid.