### PR TITLE
Add the confirm step to show a JSON summary

### DIFF
--- a/privacydesk/src/App.tsx
+++ b/privacydesk/src/App.tsx
@@ -2,6 +2,7 @@ import { AppBar } from '@progress/kendo-react-layout';
 import { Link, Routes, Route, Navigate } from 'react-router-dom';
 import RequestsPage from './pages/RequestsPage';
 import Wizard from './pages/NewRequest/Wizard';
+import CasePage from './pages/CasePage';
 
 export default function App() {
   return (
@@ -23,6 +24,7 @@ export default function App() {
           <Route path="/requests" element={<RequestsPage />} />
           <Route path="/new" element={<Wizard />} />
           <Route path="/settings" element={<div>Settings (placeholder)</div>} />
+          <Route path="/case/:id" element={<CasePage />} />
           <Route path="*" element={<Navigate to="/requests" replace />} />
         </Routes>
       </main>

--- a/privacydesk/src/pages/CasePage.tsx
+++ b/privacydesk/src/pages/CasePage.tsx
@@ -1,0 +1,14 @@
+import { useParams } from 'react-router-dom';
+import { useStore } from '../store';
+
+export default function CasePage() {
+  const { id } = useParams();
+  const req = useStore((s) => s.requests.find((r) => r.id === id));
+  if (!req) return <div>Case not found.</div>;
+  return (
+    <div>
+      <h2>Case {req.id}</h2>
+      <pre>{JSON.stringify(req, null, 2)}</pre>
+    </div>
+  );
+}

--- a/privacydesk/src/pages/NewRequest/StepConfirm.tsx
+++ b/privacydesk/src/pages/NewRequest/StepConfirm.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@progress/kendo-react-buttons';
+import { useNavigate } from 'react-router-dom';
+import type { RequestType } from '../../types';
+import { useStore } from '../../store';
+
+export interface StepConfirmValue {
+	requester: { name: string; email: string; country?: string };
+	details: { type: RequestType; notes: string; idProofReceived: boolean };
+}
+
+export interface StepConfirmProps {
+	value: StepConfirmValue;
+}
+
+export default function StepConfirm({ value }: StepConfirmProps) {
+	const navigate = useNavigate();
+	const addRequest = useStore((s) => s.addRequest);
+	const slaDays = useStore((s) => s.settings.slaDays);
+	const requesterValid = value.requester.name.trim() && /.+@.+\..+/.test(value.requester.email.trim());
+
+	const handleCreate = () => {
+		const { requester, details } = value;
+		const days = slaDays[details.type] ?? 30;
+		const due = new Date();
+		due.setDate(due.getDate() + days);
+
+		const created = addRequest({
+			type: details.type,
+			requester: { email: requester.email, name: requester.name, country: requester.country },
+			dueAt: due.toISOString(),
+			owner: 'Unassigned',
+			notes: details.notes,
+			idProofReceived: details.idProofReceived,
+		} as any);
+
+		navigate(`/case/${created.id}`);
+	};
+
+	return (
+		<div>
+			<pre>{JSON.stringify(value, null, 2)}</pre>
+			<Button themeColor="primary" onClick={handleCreate} disabled={!requesterValid}>Create</Button>
+		</div>
+	);
+}
+

--- a/privacydesk/src/pages/NewRequest/Wizard.tsx
+++ b/privacydesk/src/pages/NewRequest/Wizard.tsx
@@ -3,6 +3,7 @@ import { Stepper } from '@progress/kendo-react-layout';
 import { Button } from '@progress/kendo-react-buttons';
 import StepRequester, { type Requester } from './StepRequester';
 import StepDetails, { type StepDetailsValue } from './StepDetails';
+import StepConfirm from './StepConfirm';
 
 type StepIndex = 0 | 1 | 2;
 
@@ -14,24 +15,21 @@ const steps: Array<{ label: string }> = [
 
 // Step component for Confirm remains a placeholder
 
-function StepConfirm() {
-	return (
-		<div>
-			<h3>Confirm</h3>
-			<p>Review and confirm the request.</p>
-		</div>
-	);
-}
+// StepConfirm is imported as a component
 
 export default function Wizard() {
 	const [active, setActive] = useState<StepIndex>(0);
 	const [requester, setRequester] = useState<Requester>({ name: '', email: '', country: '' });
 		const [details, setDetails] = useState<StepDetailsValue>({ type: 'access', notes: '', idProofReceived: false });
 
-	const onStepChange = (e: any) => {
-		const next = Math.max(0, Math.min(steps.length - 1, Number(e.value) || 0)) as StepIndex;
-		setActive(next);
-	};
+		const onStepChange = (e: any) => {
+			const next = Math.max(0, Math.min(steps.length - 1, Number(e.value) || 0)) as StepIndex;
+			// Prevent skipping ahead if requester is not valid yet
+			if (next >= 1 && !canProceedFromRequester) {
+				return; // stay on current step until valid
+			}
+			setActive(next);
+		};
 
 		const handleBack = () => setActive((prev) => Math.max(0, (prev - 1) as StepIndex) as StepIndex);
 		const handleNext = () => setActive((prev) => Math.min(steps.length - 1, (prev + 1) as StepIndex) as StepIndex);
@@ -59,10 +57,12 @@ export default function Wizard() {
 										onNext={handleNext}
 									/>
 								)}
-								{active === 2 && <StepConfirm />}
+										{active === 2 && (
+											<StepConfirm value={{ requester, details }} />
+										)}
 							</div>
 
-							{active !== 1 && (
+							{active !== 1 && active !== 2 && (
 								<div>
 									<Button onClick={handleBack} disabled={active === 0}>Back</Button>
 									<Button

--- a/privacydesk/src/pages/RequestsPage.tsx
+++ b/privacydesk/src/pages/RequestsPage.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { RequestGrid, FiltersBar } from '../components/Requests';
 import { seedRequests } from '../data/seed';
 import type { Request } from '../types';
+import { useStore } from '../store';
 
 export default function RequestsPage() {
   const owners = useMemo(
@@ -22,6 +23,8 @@ export default function RequestsPage() {
   const [dateFrom, setDateFrom] = useState<Date | null>(null);
   const [dateTo, setDateTo] = useState<Date | null>(null);
 
+  const storeRequests = useStore((s) => s.requests);
+
   return (
     <div>
       <h2>Requests</h2>
@@ -38,11 +41,7 @@ export default function RequestsPage() {
         setDateTo={setDateTo}
         owners={owners}
       />
-      <RequestGrid
-        data={seedRequests.filter(
-          (req): req is Request & { owner: string } => typeof req.owner === 'string'
-        )}
-      />
+  <RequestGrid data={storeRequests.filter((req): req is Request & { owner: string } => typeof req.owner === 'string')} />
     </div>
   );
 }

--- a/privacydesk/src/store.ts
+++ b/privacydesk/src/store.ts
@@ -1,0 +1,53 @@
+import { create } from 'zustand/react';
+import type { Request, RequestType, Status } from './types';
+import { seedRequests } from './data/seed';
+
+export interface Settings {
+  slaDays: Record<RequestType, number>;
+}
+
+export interface DsrRequest extends Request {
+  notes?: string;
+  idProofReceived?: boolean;
+}
+
+interface StoreState {
+  requests: DsrRequest[];
+  settings: Settings;
+  addRequest: (input: Omit<DsrRequest, 'id' | 'submittedAt' | 'dueAt' | 'status'> & Partial<Pick<DsrRequest, 'status'>>) => DsrRequest;
+}
+
+function nextId(existing: { id: string }[]): string {
+  const max = existing
+    .map((r) => Number(String(r.id).replace(/[^0-9]/g, '')) || 0)
+    .reduce((a, b) => Math.max(a, b), 1000);
+  return `REQ-${max + 1}`;
+}
+
+export const useStore = create<StoreState>((set, get) => ({
+  requests: seedRequests as DsrRequest[],
+  settings: {
+    slaDays: {
+      access: 30,
+      delete: 30,
+      export: 30,
+      correct: 30,
+    },
+  },
+  addRequest: (input) => {
+    const { requests } = get();
+    const id = nextId(requests);
+    const submittedAt = new Date().toISOString();
+    const status: Status = (input.status as Status) ?? 'new';
+    const created: DsrRequest = {
+      ...input,
+      id,
+      submittedAt,
+      status,
+      // ensure dueAt provided by caller; can be filled before calling
+      dueAt: (input as any).dueAt,
+    } as DsrRequest;
+    set({ requests: [created, ...requests] });
+    return created;
+  },
+}));


### PR DESCRIPTION
Add the confirm step to show a JSON summary and create the request via a small Zustand store, compute dueAt from SLA, and navigate to the case page
